### PR TITLE
return if file does not exist

### DIFF
--- a/lib/kitchen/driver/terraform.rb
+++ b/lib/kitchen/driver/terraform.rb
@@ -37,7 +37,8 @@ module Kitchen
       end
 
       def destroy(_state = nil)
-        return if !File.exist?(provisioner[:state]) || current_state.empty?
+        return unless File.exist?(provisioner[:state])
+        return if current_state.empty?
 
         create
         validate_configuration_files


### PR DESCRIPTION
file exist statement was coming back true, then
the or statement was getting called and
current_state tried to read the missing file

----

I tried an `or` statement and that did work, but thought this was cleaner.
The other option is to put the file exist statement in the client execute show command method