### PR TITLE
Update docs to suggest the latest version of the driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Once Bundler is installed, add kitchen-terraform to the project's Gemfile:
 ```rb
 source 'https://rubygems.org'
 
-gem 'kitchen-terraform', '~> 0.1'
+gem 'kitchen-terraform', '~> 0.3'
 ```
 
 Then, use Bundler to install the gems:


### PR DESCRIPTION
The docs should always be kept up to date and reflect the current state of reality. This PR suggest to use the latest available set of versions of the driver so that users don't get confused when starting out with using the driver.